### PR TITLE
add [#hook], hook!, original! functionality

### DIFF
--- a/skyline_macro/src/attributes/mod.rs
+++ b/skyline_macro/src/attributes/mod.rs
@@ -1,35 +1,39 @@
 use proc_macro2::TokenStream as TokenStream2;
 use quote::ToTokens;
 use syn::parse::{Parse, ParseStream};
+use syn::{parenthesized, token, Token};
 
-pub struct Attrs {
+pub struct MainAttrs {
     name: String,
-
 }
 
-impl Parse for Attrs {
-    fn parse(input: ParseStream) -> syn::Result<Self> {
-        let meta: syn::MetaNameValue = match input.parse() {
-            Ok(x) => x,
-            Err(_) => return Ok(Attrs { name: "skyline_rust_plugin".into() })
-        };
+mod kw {
+    syn::custom_keyword!(name);
+    syn::custom_keyword!(replace);
+    syn::custom_keyword!(symbol);
+    syn::custom_keyword!(offset);
+}
 
-        if meta.path.get_ident().unwrap().to_string() == "name" {
+impl Parse for MainAttrs {
+    fn parse(input: ParseStream) -> syn::Result<Self> {
+        if input.peek(kw::name) {
+            let meta: syn::MetaNameValue = input.parse()?;
+
             match meta.lit {
                 syn::Lit::Str(string) => {
-                    Ok(Attrs {
+                    Ok(MainAttrs {
                         name: string.value()
                     })
                 }
                 _ => panic!("Invalid literal, must be a string")
             }
         } else {
-            panic!("Attributes other than 'name' not allowed");
+            Ok(MainAttrs { name: "skyline_rust_plugin".into() })
         }
     }
 }
 
-impl ToTokens for Attrs {
+impl ToTokens for MainAttrs {
     fn to_tokens(&self, tokens: &mut TokenStream2) {
         let name = &self.name[..];
         quote::quote!(
@@ -37,3 +41,88 @@ impl ToTokens for Attrs {
         ).to_tokens(tokens);
     }
 }
+
+#[derive(Default)]
+pub struct HookAttrs {
+    pub replace: Option<syn::Path>,
+    pub symbol: Option<syn::LitStr>,
+    pub offset: Option<syn::LitInt>
+}
+
+fn merge(attr1: HookAttrs, attr2: HookAttrs) -> HookAttrs {
+    let (
+        HookAttrs { replace: r1, symbol: s1, offset: o1},
+        HookAttrs { replace: r2, symbol: s2, offset: o2},
+    ) = (attr1, attr2);
+
+
+    HookAttrs {
+        replace: r1.or(r2),
+        offset: o1.or(o2),
+        symbol: s1.or(s2)
+    }
+}
+
+impl Parse for HookAttrs {
+    fn parse(input: ParseStream) -> syn::Result<Self> {
+        let look = input.lookahead1();
+        let attr = if look.peek(kw::symbol) {
+            let MetaItem::<kw::replace, syn::LitStr> { item: string, .. } = input.parse()?;
+            
+            let mut a = HookAttrs::default();
+            a.symbol = Some(string);
+            a
+        } else if look.peek(kw::offset) {
+            let MetaItem::<kw::replace, syn::LitInt> { item: int, .. } = input.parse()?;
+            
+            let mut a = HookAttrs::default();
+            a.offset = Some(int);
+            a
+        } else if look.peek(kw::replace) {
+            let MetaItem::<kw::replace, syn::Path> { item: replace, .. } = input.parse()?;
+            
+            let mut a = HookAttrs::default();
+            a.replace = Some(replace);
+            a
+        } else {
+            return Err(look.error());
+        };
+
+        Ok(if input.peek(Token![,]) {
+            let _: Token![,] = input.parse()?;
+            if input.is_empty() {
+                attr
+            } else {
+                merge(attr, input.parse()?)
+            }
+        } else {
+            attr
+        })
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct MetaItem<Keyword: Parse, Item: Parse> {
+    pub ident: Keyword,
+    pub item: Item,
+}
+
+impl<Keyword: Parse, Item: Parse> Parse for MetaItem<Keyword, Item> {
+    fn parse(input: ParseStream) -> syn::Result<Self> {
+        let ident = input.parse()?;
+        let item = if input.peek(token::Paren) {
+            let content;
+            parenthesized!(content in input);
+            content.parse()?
+        } else {
+            input.parse::<Token![=]>()?;
+            input.parse()?
+        };
+
+        Ok(Self {
+            ident,
+            item
+        })
+    }
+}
+

--- a/skyline_macro/src/install_fn.rs
+++ b/skyline_macro/src/install_fn.rs
@@ -1,0 +1,32 @@
+use quote::{quote, quote_spanned, ToTokens};
+use super::attributes::HookAttrs;
+use proc_macro2::Span;
+
+pub fn generate(name: &syn::Ident, orig: &syn::Ident, attrs: &HookAttrs) -> impl ToTokens {
+    let _install_fn = quote::format_ident!("{}_skyline_internal_install_hook", name);
+
+    let replace = attrs.replace
+                    .as_ref()
+                    .map(ToTokens::into_token_stream)
+                    .unwrap_or_else(||{
+                        quote_spanned!(Span::call_site() =>
+                            compile_error!("Missing 'replace' item in hook macro");
+                        )
+                    });
+
+    quote!{
+        fn #_install_fn() {
+            if (::skyline::hooks::A64HookFunction as *const ()).is_null() {
+                panic!("A64HookFunction is null");
+            }
+
+            unsafe {
+                ::skyline::hooks::A64HookFunction(
+                    #replace as *const ::skyline::libc::c_void,
+                    #name as *const ::skyline::libc::c_void,
+                    &mut #orig as *mut *mut ::skyline::libc::c_void 
+                )
+            }
+        }
+    }
+}

--- a/skyline_macro/src/lib.rs
+++ b/skyline_macro/src/lib.rs
@@ -36,19 +36,6 @@ pub fn main(attrs: TokenStream, item: TokenStream) -> TokenStream {
     
     main_function.sig.ident = Ident::new("main", Span::call_site());
 
-    // allow hook!
-    let hook_stmt: Stmt = parse_quote! {
-        macro_rules! hook {
-            ($symbol:ident, $replace:ident) => { 
-                hook(
-                    $symbol as *const libc::c_void,
-                    $replace as *const libc::c_void,
-                    unsafe { &mut concat_idents!(orig_, $replace) as *mut *mut libc::c_void })
-            }
-        }
-    };
-    main_function.block.stmts.insert(0, hook_stmt);
-
     let mut output = TokenStream2::new();
 
     quote!(

--- a/src/hooks.rs
+++ b/src/hooks.rs
@@ -1,4 +1,18 @@
+#![feature(concat_idents)]
 use crate::alloc::string::String;
+
+extern "C" {
+    pub fn A64HookFunction(symbol: *const libc::c_void, replace: *const libc::c_void, result: *mut *mut libc::c_void);
+}
+
+#[macro_export] macro_rules! hook_install {
+    ($symbol:ident, $replace:ident) => { 
+        unsafe { hooks::A64HookFunction(
+            $symbol as *const libc::c_void,
+            $replace as *const libc::c_void,
+            &mut concat_idents!(orig_, $replace) as *mut *mut libc::c_void )}
+    }
+}
 
 pub struct HookInfo {
     /// Name of the function being used as the override

--- a/src/hooks.rs
+++ b/src/hooks.rs
@@ -1,17 +1,7 @@
-#![feature(concat_idents)]
 use crate::alloc::string::String;
 
 extern "C" {
     pub fn A64HookFunction(symbol: *const libc::c_void, replace: *const libc::c_void, result: *mut *mut libc::c_void);
-}
-
-#[macro_export] macro_rules! hook_install {
-    ($symbol:ident, $replace:ident) => { 
-        unsafe { hooks::A64HookFunction(
-            $symbol as *const libc::c_void,
-            $replace as *const libc::c_void,
-            &mut concat_idents!(orig_, $replace) as *mut *mut libc::c_void )}
-    }
 }
 
 pub struct HookInfo {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,7 +24,7 @@ pub mod nn;
 #[doc(inline)]
 pub use {
     libc,
-    skyline_macro::{main, hook}, 
+    skyline_macro::{main, hook, install_hook}, 
     hooks::iter_hooks,
 };
 


### PR DESCRIPTION
Allows for the following code:

```rust
#[skyline::hook]
pub extern "C" fn handleNnAccountGetNickname(nickname: *mut Nickname, userID: *const Uid) -> u64 {
    let rc = original!()(nickname, userID);
    return rc;
}

#[skyline::main(name = "module_name_test")]
pub fn main() {
    hook_install!(GetNickname, handleNnAccountGetNickname);
}
```

It will expand as:
```rust
#[no_mangle]
pub extern "C" fn handleNnAccountGetNickname(nickname: *mut Nickname, userID: *const Uid) -> u64 {
    let rc = unsafe {
        core::mem::transmute::<_, extern "C" fn(nickname: *mut Nickname, userID: *const Uid) -> u64>(
            orig_handleNnAccountGetNickname as *const (),
        )
    }(nickname, userID);
    return rc;
}
#[allow(non_upper_case_globals)]
static mut orig_handleNnAccountGetNickname: *mut libc::c_void = 0 as *mut libc::c_void;
const __SKYLINE_INTERNAL_MODULE_LEN: usize = "module_name_test".len() + 1;
#[link_section = ".rodata.module_name"]
pub static __MODULE_NAME: ::skyline::build::ModuleName<__SKYLINE_INTERNAL_MODULE_LEN> =
    ::skyline::build::ModuleName::new((b"module_name_test\x00"));
#[no_mangle]
pub extern "C" fn main() {
    hooks:A64HookFunction(
        GetNickname as *const libc::c_void,
        handleNnAccountGetNickname as *const libc::c_void,
        unsafe { &mut orig_handleNnAccountGetNickname as *mut *mut libc::c_void },
    );
}
```