### PR TITLE
add from_c_str and patch given text offset

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -49,9 +49,9 @@ pub fn c_str(string: &str) -> *const u8 {
 pub unsafe fn from_c_str(c_str: *const u8) -> String {
     let name_slice = Vec::from_raw_parts(c_str as *mut _, strlen(c_str), strlen(c_str));
     match core::str::from_utf8(&name_slice) {
-        Ok(v) => return v.to_owned(),
+        Ok(v) => v.to_owned(),
         Err(e) => panic!("Invalid UTF-8 sequence: {}", e),
-    };
+    }
 }
 
 /// A set of items that will likely be useful to import anyway

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,8 @@
 #![allow(incomplete_features)]
 #![feature(alloc_error_handler, lang_items, start, global_asm, const_generics, impl_trait_in_bindings, proc_macro_hygiene, alloc_prelude, panic_info_message, try_trait, track_caller)]
 
+use libc::strlen;
+
 /// The rust core allocation and collections library
 pub extern crate alloc;
 
@@ -40,6 +42,18 @@ pub use {
 /// Helper to convert a str to a *const u8 (to be replaced)
 pub fn c_str(string: &str) -> *const u8 {
     string.as_bytes().as_ptr()
+}
+
+
+/// Helper to convert a C-str to a Rust string
+pub unsafe fn from_c_str(c_str: *const u8) -> String {
+    let mut name_slice = Vec::from_raw_parts(c_str as *mut _, strlen(c_str), strlen(c_str));
+    let name = match core::str::from_utf8(&name_slice) {
+        Ok(v) => v.to_owned(),
+        Err(e) => panic!("Invalid UTF-8 sequence: {}", e),
+    };
+
+    name
 }
 
 /// A set of items that will likely be useful to import anyway

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -47,13 +47,11 @@ pub fn c_str(string: &str) -> *const u8 {
 
 /// Helper to convert a C-str to a Rust string
 pub unsafe fn from_c_str(c_str: *const u8) -> String {
-    let mut name_slice = Vec::from_raw_parts(c_str as *mut _, strlen(c_str), strlen(c_str));
-    let name = match core::str::from_utf8(&name_slice) {
-        Ok(v) => v.to_owned(),
+    let name_slice = Vec::from_raw_parts(c_str as *mut _, strlen(c_str), strlen(c_str));
+    match core::str::from_utf8(&name_slice) {
+        Ok(v) => return v.to_owned(),
         Err(e) => panic!("Invalid UTF-8 sequence: {}", e),
     };
-
-    name
 }
 
 /// A set of items that will likely be useful to import anyway

--- a/src/patching.rs
+++ b/src/patching.rs
@@ -27,6 +27,12 @@ pub unsafe fn patch_str(offset: usize, string: &str) -> Result<(), Error> {
 /// Overwrite a value in read-only data with a passed value given an offset from the start of .text
 pub unsafe fn patch_data<T: Sized + Copy>(offset: usize, val: &T) -> Result<(), Error> {
     let text_ptr = getRegionAddress(Region::Text) as *const u8;
+    patch_data_from_text(text_ptr, offset, val)
+}
+
+/// Overwrite a value in read-only data with a passed value given an offset from the start of .text
+pub unsafe fn patch_data_from_text<T: Sized + Copy>(text_offset: *const u8, offset: usize, val: &T) -> Result<(), Error> {
+    let text_ptr = text_offset;
     let data_ptr = text_ptr.offset(offset as isize);
 
     sky_memcpy(data_ptr as _, val as *const _ as _, core::mem::size_of::<T>()).ok()?;


### PR DESCRIPTION
Example plugin usage:
```rust
let name = from_c_str(&(*pOutModule).Name as *const u8);
println!("[handleLoadModule] NRO name: {}\n", name);
let text_start = (*(*pOutModule).ModuleObject).module_base;
println!("Module base: {}\n", text_start);
if name.starts_with("common") {
    println!("Is common!");
    // raw const_value_table is at : 0x635b70
    let fighter_status_kind_fall : u64 = 0x8ee6c39e9be4f0b5;
    let res = match patch_data_from_text(text_start as *const u8, 0x6362b8, &fighter_status_kind_fall) {
        Ok(v) => format!("Patched!"),
        Err(e) => format!("Error patching with e: {}", e)
    };

    println!("{}", res);
}
```