### PR TITLE
Add public visibility to hooks

### DIFF
--- a/skyline_macro/src/install_fn.rs
+++ b/skyline_macro/src/install_fn.rs
@@ -26,7 +26,7 @@ pub fn generate(name: &syn::Ident, orig: &syn::Ident, attrs: &HookAttrs) -> impl
                     });
 
     quote!{
-        fn #_install_fn() {
+        pub fn #_install_fn() {
             if (::skyline::hooks::A64HookFunction as *const ()).is_null() {
                 panic!("A64HookFunction is null");
             }

--- a/skyline_macro/src/lib.rs
+++ b/skyline_macro/src/lib.rs
@@ -94,7 +94,7 @@ pub fn hook(attrs: TokenStream, input: TokenStream) -> TokenStream {
         #install_fn
         
         #[allow(non_upper_case_globals)]
-        static mut #_orig_fn: *mut ::skyline::libc::c_void = 0 as *mut ::skyline::libc::c_void;
+        pub static mut #_orig_fn: *mut ::skyline::libc::c_void = 0 as *mut ::skyline::libc::c_void;
     ).to_tokens(&mut output);
 
     output.into()


### PR DESCRIPTION
Allows for hook composability by modifying macro function generation to be used outside of the defined module.