### PR TITLE
Allow specifying relative offsets to replaced symbol in hooks, add functions for pointer patching

### DIFF
--- a/skyline_macro/src/attributes/mod.rs
+++ b/skyline_macro/src/attributes/mod.rs
@@ -12,6 +12,7 @@ mod kw {
     syn::custom_keyword!(name);
     syn::custom_keyword!(replace);
     syn::custom_keyword!(symbol);
+    syn::custom_keyword!(pointer_offset);
     syn::custom_keyword!(offset);
 }
 
@@ -47,14 +48,15 @@ impl ToTokens for MainAttrs {
 pub struct HookAttrs {
     pub replace: Option<syn::Path>,
     pub symbol: Option<syn::LitStr>,
+    pub pointer_offset: Option<syn::Expr>,
     pub offset: Option<syn::Expr>,
     pub inline: bool,
 }
 
 fn merge(attr1: HookAttrs, attr2: HookAttrs) -> HookAttrs {
     let (
-        HookAttrs { replace: r1, symbol: s1, offset: o1, inline: i1 },
-        HookAttrs { replace: r2, symbol: s2, offset: o2, inline: i2 },
+        HookAttrs { replace: r1, symbol: s1, pointer_offset: so1, offset: o1, inline: i1 },
+        HookAttrs { replace: r2, symbol: s2, pointer_offset: so2, offset: o2, inline: i2 },
     ) = (attr1, attr2);
 
 
@@ -62,6 +64,7 @@ fn merge(attr1: HookAttrs, attr2: HookAttrs) -> HookAttrs {
         replace: r1.or(r2),
         offset: o1.or(o2),
         symbol: s1.or(s2),
+        pointer_offset: so1.or(so2),
         inline: i1 || i2
     }
 }
@@ -80,6 +83,12 @@ impl Parse for HookAttrs {
             
             let mut a = HookAttrs::default();
             a.offset = Some(offset);
+            a
+        } else if look.peek(kw::pointer_offset) {
+            let MetaItem::<kw::pointer_offset, syn::Expr> { item: pointer_offset, .. } = input.parse()?;
+
+            let mut a = HookAttrs::default();
+            a.pointer_offset = Some(pointer_offset);
             a
         } else if look.peek(kw::replace) {
             let MetaItem::<kw::replace, syn::Path> { item: replace, .. } = input.parse()?;

--- a/skyline_macro/src/install_fn.rs
+++ b/skyline_macro/src/install_fn.rs
@@ -4,6 +4,11 @@ use proc_macro2::Span;
 
 pub fn generate(name: &syn::Ident, orig: &syn::Ident, attrs: &HookAttrs) -> impl ToTokens {
     let _install_fn = quote::format_ident!("{}_skyline_internal_install_hook", name);
+    let pointer_offset = attrs
+                    .pointer_offset
+                    .as_ref()
+                    .map(ToTokens::into_token_stream)
+                    .unwrap_or(quote! {0});
 
     let replace = attrs.replace
                     .as_ref()
@@ -44,7 +49,7 @@ pub fn generate(name: &syn::Ident, orig: &syn::Ident, attrs: &HookAttrs) -> impl
 
                 unsafe {
                     ::skyline::hooks::A64InlineHook(
-                        #replace as *const ::skyline::libc::c_void,
+                        ((#replace as *const u8).offset(#pointer_offset) as *const ::skyline::libc::c_void),
                         #name as *const ::skyline::libc::c_void,
                     )
                 }
@@ -59,7 +64,7 @@ pub fn generate(name: &syn::Ident, orig: &syn::Ident, attrs: &HookAttrs) -> impl
 
                 unsafe {
                     ::skyline::hooks::A64HookFunction(
-                        #replace as *const ::skyline::libc::c_void,
+                        ((#replace as *const u8).offset(#pointer_offset) as *const ::skyline::libc::c_void),
                         #name as *const ::skyline::libc::c_void,
                         &mut #orig as *mut *mut ::skyline::libc::c_void 
                     )


### PR DESCRIPTION
Adds functionality useful for working with symbol maps from Skyline. Most notably, an additional offset relative to the start of the symbol can be specified to allow for convenient inline hooks with pointers like this: `#[hook(replace = my_func, pointer_offset = 0xd10, inline)]`.

Also adds functions for patching pointers and offsets with a `NOP

Implements #19 
Implements #20 