### PR TITLE
Add alternative allocator + try_from_c_str

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,8 @@
 #![allow(incomplete_features, stable_features)]
 #![feature(alloc_error_handler, lang_items, start, global_asm, const_generics, impl_trait_in_bindings, proc_macro_hygiene, alloc_prelude, panic_info_message, track_caller)]
 
+use std::str::Utf8Error;
+
 use libc::strlen;
 
 #[cfg(not(feature = "std"))]
@@ -65,6 +67,12 @@ pub unsafe fn from_c_str(c_str: *const u8) -> String {
         Ok(v) => v.to_owned(),
         Err(e) => panic!("Invalid UTF-8 sequence: {}", e),
     }
+}
+
+/// Helper to convert a C-str to a Rust string, returning an error if it failed
+pub unsafe fn try_from_c_str(c_str: *const u8) -> Result<String, Utf8Error> {
+    let name_slice = core::slice::from_raw_parts(c_str as *mut _, strlen(c_str));
+    core::str::from_utf8(&name_slice).map(|string| string.to_owned())
 }
 
 /// A set of items that will likely be useful to import anyway

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,6 +7,9 @@ use libc::strlen;
 #[cfg(not(feature = "std"))]
 use alloc::{borrow::ToOwned, string::String};
 
+#[cfg(feature = "std")]
+pub mod unix_alloc;
+
 /// The rust core allocation and collections library
 pub extern crate alloc;
 

--- a/src/unix_alloc.rs
+++ b/src/unix_alloc.rs
@@ -1,0 +1,64 @@
+use std::alloc::*;
+use crate::libc;
+
+pub struct UnixAllocator;
+
+impl UnixAllocator {
+    pub unsafe fn aligned_malloc(layout: &Layout) -> *mut u8 {
+        let mut out = std::ptr::null_mut();
+
+        let align = layout.align().max(std::mem::size_of::<usize>());
+        let ret = libc::posix_memalign(&mut out, align, layout.size());
+        if ret != 0 {
+            std::ptr::null_mut()
+        } else {
+            out as *mut u8
+        }
+    }
+
+    pub unsafe fn manual_realloc(ptr: *mut u8, old_layout: Layout, new_size: usize) -> *mut u8 {
+        let new_layout = Layout::from_size_align_unchecked(new_size, old_layout.align());
+
+        let new_ptr = Self.alloc(new_layout);
+        if !new_ptr.is_null() {
+            let size = std::cmp::min(old_layout.size(), new_size);
+            std::ptr::copy_nonoverlapping(ptr, new_ptr, size);
+            Self.dealloc(ptr, old_layout);
+        }
+        new_ptr
+    }
+}
+
+unsafe impl GlobalAlloc for UnixAllocator {
+    #[inline]
+    unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+        if layout.align() <= 16 && layout.align() <= layout.size() {
+            libc::malloc(layout.size()) as *mut u8
+        } else {
+            Self::aligned_malloc(&layout)
+        }
+    }
+
+    #[inline]
+    unsafe fn alloc_zeroed(&self, layout: Layout) -> *mut u8 {
+        if layout.align() <= 16 && layout.align() <= layout.size() {
+            libc::calloc(layout.size(), 1) as *mut u8
+        } else {
+            let ptr = self.alloc(layout);
+            if !ptr.is_null() {
+                std::ptr::write_bytes(ptr, 0, layout.size());
+            }
+            ptr
+        }
+    }
+
+    #[inline]
+    unsafe fn dealloc(&self, ptr: *mut u8, _layout: Layout) {
+        libc::free(ptr as _)
+    }
+
+    #[inline]
+    unsafe fn realloc(&self, ptr: *mut u8, layout: Layout, new_size: usize) -> *mut u8 {
+        Self::manual_realloc(ptr, layout, new_size)
+    }
+}


### PR DESCRIPTION
This allocator does the same alignment checks as [Rust STD's unix allocator](https://github.com/skyline-rs/rust/blob/master/library/std/src/sys/switch/alloc.rs), but also manually handles realloc since using the exported symbol can cause crashes on some games.

Also adds `try_from_c_str` so that you don't panic if it isn't valid UTF-8