### PR TITLE
Bump libc-nnsdk to 0.4.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ readme = "README.md"
 [dependencies]
 skyline_macro = { path = "./skyline_macro", version = "0.2.0" }
 nnsdk = { git = "https://github.com/ultimate-research/nnsdk-rs" }
-libc-nnsdk = "0.2.0"
+libc-nnsdk = "0.4.0"
 
 [features]
 default = ["std"]


### PR DESCRIPTION
This solves the current dependency [issue](https://github.com/jam1garner/cargo-skyline/issues/60) in [cargo-skyline](https://github.com/jam1garner/cargo-skyline), where cargo-skyline fails to build nro projects.

As i understand it, libc-nnsdk and nnsdk needs to be in "sync", so hardcoding the libc-nnsdk version in cargo.toml might cause this issue to reoccur in the future.